### PR TITLE
More fixes and tweaks

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,12 @@ First you install it:
 pip install sphinx-markdown-parser
 ```
 
+If using MarkdownParser, you may also want to install some extensions for it:
+
+```
+pip install pymdown-extensions
+```
+
 Then add this to your Sphinx conf.py:
 
 ```
@@ -37,8 +43,6 @@ def setup(app):
         'enable_auto_doc_ref': True,
         'enable_auto_toc_tree': True,
         'enable_eval_rst': True,
-        'enable_inline_math': True,
-        'enable_math': True,
         'extensions': [
             'extra',
             'nl2br',
@@ -46,6 +50,7 @@ def setup(app):
             'smarty',
             'toc',
             'wikilinks',
+            'pymdownx.arithmatex',
         ],
     }, True)
 

--- a/README.md
+++ b/README.md
@@ -39,6 +39,14 @@ def setup(app):
         'enable_eval_rst': True,
         'enable_inline_math': True,
         'enable_math': True,
+        'extensions': [
+            'extra',
+            'nl2br',
+            'sane_lists',
+            'smarty',
+            'toc',
+            'wikilinks',
+        ],
     }, True)
 
 # for CommonMarkParser

--- a/README.rst
+++ b/README.rst
@@ -23,41 +23,41 @@ First you install it:
 
 ::
 
-   pip install sphinx-markdown-parser
+    pip install sphinx-markdown-parser
 
 Then add this to your Sphinx conf.py:
 
 ::
 
-   # for MarkdownParser
-   from sphinx_markdown_parser.parser import MarkdownParser
+    # for MarkdownParser
+    from sphinx_markdown_parser.parser import MarkdownParser
 
-   def setup(app):
-       app.add_source_suffix('.md', 'markdown')
-       app.add_source_parser(MarkdownParser)
-       app.add_config_value('markdown_parser_config', {
-           'auto_toc_tree_section': 'Content',
-           'enable_auto_doc_ref': True,
-           'enable_auto_toc_tree': True,
-           'enable_eval_rst': True,
-           'enable_inline_math': True,
-           'enable_math': True,
-       }, True)
+    def setup(app):
+        app.add_source_suffix('.md', 'markdown')
+        app.add_source_parser(MarkdownParser)
+        app.add_config_value('markdown_parser_config', {
+            'auto_toc_tree_section': 'Content',
+            'enable_auto_doc_ref': True,
+            'enable_auto_toc_tree': True,
+            'enable_eval_rst': True,
+            'enable_inline_math': True,
+            'enable_math': True,
+        }, True)
 
-   # for CommonMarkParser
-   from recommonmark.parser import CommonMarkParser
+    # for CommonMarkParser
+    from recommonmark.parser import CommonMarkParser
 
-   def setup(app):
-       app.add_source_suffix('.md', 'markdown')
-       app.add_source_parser(CommonMarkParser)
-       app.add_config_value('markdown_parser_config', {
-           'auto_toc_tree_section': 'Content',
-           'enable_auto_doc_ref': True,
-           'enable_auto_toc_tree': True,
-           'enable_eval_rst': True,
-           'enable_inline_math': True,
-           'enable_math': True,
-       }, True)
+    def setup(app):
+        app.add_source_suffix('.md', 'markdown')
+        app.add_source_parser(CommonMarkParser)
+        app.add_config_value('markdown_parser_config', {
+            'auto_toc_tree_section': 'Content',
+            'enable_auto_doc_ref': True,
+            'enable_auto_toc_tree': True,
+            'enable_eval_rst': True,
+            'enable_inline_math': True,
+            'enable_math': True,
+        }, True)
 
 This allows you to write both ``.md`` and ``.rst`` files inside of the
 same project.
@@ -65,7 +65,7 @@ same project.
 Links
 ~~~~~
 
-For all links in commonmark that aren’t explicit URLs, they are treated
+For all links in commonmark that aren't explicit URLs, they are treated
 as cross references with the
 ```:any:`` <http://www.sphinx-doc.org/en/stable/markup/inline.html#role-any>`__
 role. This allows referencing a lot of things including files, labels,
@@ -85,16 +85,16 @@ To use the advanced markdown to rst transformations you must add
 
 .. code:: python
 
-   # At top on conf.py (with other import statements)
-   from sphinx_markdown_parser.transform import AutoStructify
+    # At top on conf.py (with other import statements)
+    from sphinx_markdown_parser.transform import AutoStructify
 
-   # At the bottom of conf.py
-   def setup(app):
-       app.add_config_value('markdown_parser_config', {
-               'url_resolver': lambda url: github_doc_root + url,
-               'auto_toc_tree_section': 'Contents',
-               }, True)
-       app.add_transform(AutoStructify)
+    # At the bottom of conf.py
+    def setup(app):
+        app.add_config_value('markdown_parser_config', {
+                'url_resolver': lambda url: github_doc_root + url,
+                'auto_toc_tree_section': 'Contents',
+                }, True)
+        app.add_transform(AutoStructify)
 
 See https://github.com/rtfd/recommonmark/blob/master/docs/conf.py for a
 full example.
@@ -103,16 +103,16 @@ AutoStructify comes with the following options. See
 http://recommonmark.readthedocs.org/en/latest/auto_structify.html for
 more information about the specific features.
 
--  **enable_auto_toc_tree**: enable the Auto Toc Tree feature.
--  **auto_toc_tree_section**: when True, Auto Toc Tree will only be
+-  **enable\_auto\_toc\_tree**: enable the Auto Toc Tree feature.
+-  **auto\_toc\_tree\_section**: when True, Auto Toc Tree will only be
    enabled on section that matches the title.
--  **enable_auto_doc_ref**: enable the Auto Doc Ref feature.
+-  **enable\_auto\_doc\_ref**: enable the Auto Doc Ref feature.
    **Deprecated**
--  **enable_math**: enable the Math Formula feature.
--  **enable_inline_math**: enable the Inline Math feature.
--  **enable_eval_rst**: enable the evaluate embedded reStructuredText
+-  **enable\_math**: enable the Math Formula feature.
+-  **enable\_inline\_math**: enable the Inline Math feature.
+-  **enable\_eval\_rst**: enable the evaluate embedded reStructuredText
    feature.
--  **url_resolver**: a function that maps a existing relative position
+-  **url\_resolver**: a function that maps a existing relative position
    in the document to a http link
 
 Development

--- a/README.rst
+++ b/README.rst
@@ -25,6 +25,13 @@ First you install it:
 
     pip install sphinx-markdown-parser
 
+If using MarkdownParser, you may also want to install some extensions
+for it:
+
+::
+
+    pip install pymdown-extensions
+
 Then add this to your Sphinx conf.py:
 
 ::
@@ -40,8 +47,6 @@ Then add this to your Sphinx conf.py:
             'enable_auto_doc_ref': True,
             'enable_auto_toc_tree': True,
             'enable_eval_rst': True,
-            'enable_inline_math': True,
-            'enable_math': True,
             'extensions': [
                 'extra',
                 'nl2br',
@@ -49,7 +54,8 @@ Then add this to your Sphinx conf.py:
                 'smarty',
                 'toc',
                 'wikilinks',
-            ]
+                'pymdownx.arithmatex',
+            ],
         }, True)
 
     # for CommonMarkParser

--- a/README.rst
+++ b/README.rst
@@ -42,6 +42,14 @@ Then add this to your Sphinx conf.py:
             'enable_eval_rst': True,
             'enable_inline_math': True,
             'enable_math': True,
+            'extensions': [
+                'extra',
+                'nl2br',
+                'sane_lists',
+                'smarty',
+                'toc',
+                'wikilinks',
+            ]
         }, True)
 
     # for CommonMarkParser

--- a/sphinx_markdown_parser/markdown_parser.py
+++ b/sphinx_markdown_parser/markdown_parser.py
@@ -237,12 +237,15 @@ class MarkdownParser(parsers.Parser):
         elif lvl == self.parse_stack_h[-1]:
             x = self.parse_stack_w.pop()
             assert isinstance(x, nodes.section) or isinstance(x, nodes.document)
+            self.parse_stack_h.pop()
             self.append_node(self.new_section(heading))
         elif lvl < self.parse_stack_h[-1]:
             x = self.parse_stack_w.pop()
             assert isinstance(x, nodes.section) or isinstance(x, nodes.document)
+            self.parse_stack_h.pop()
             x = self.parse_stack_w.pop()
             assert isinstance(x, nodes.section) or isinstance(x, nodes.document)
+            self.parse_stack_h.pop()
             self.append_node(self.new_section(heading))
         # don't rewind past this, when departing the <hn> tag
         self.parse_stack_w_old = len(self.parse_stack_w)

--- a/sphinx_markdown_parser/markdown_parser.py
+++ b/sphinx_markdown_parser/markdown_parser.py
@@ -269,21 +269,11 @@ class MarkdownParser(parsers.Parser):
         return section
 
     def start_new_section(self, lvl, heading):
-        if lvl > self.parse_stack_h[-1]:
-            self.append_node(self.new_section(heading))
-        elif lvl == self.parse_stack_h[-1]:
+        while lvl <= self.parse_stack_h[-1]:
             x = self.parse_stack_w.pop()
-            assert isinstance(x, (nodes.section, nodes.document))
+            assert isinstance(x, nodes.section)
             self.parse_stack_h.pop()
-            self.append_node(self.new_section(heading))
-        elif lvl < self.parse_stack_h[-1]:
-            x = self.parse_stack_w.pop()
-            assert isinstance(x, (nodes.section, nodes.document))
-            self.parse_stack_h.pop()
-            x = self.parse_stack_w.pop()
-            assert isinstance(x, (nodes.section, nodes.document))
-            self.parse_stack_h.pop()
-            self.append_node(self.new_section(heading))
+        self.append_node(self.new_section(heading))
         self.reset_w_old()
         self.parse_stack_h.append(lvl)
         assert isinstance(self.parse_stack_w[-1], nodes.section)

--- a/tests/test_markdown.py
+++ b/tests/test_markdown.py
@@ -11,10 +11,23 @@ from docutils.core import publish_parts
 from commonmark import Parser
 from sphinx_markdown_parser.parser import MarkdownParser
 
+
+DEFAULT_TEST_CONFIG = {
+    'extensions': [
+        'extra',
+        'nl2br',
+        'sane_lists',
+        'smarty',
+        'toc',
+        'wikilinks',
+    ]
+}
+
+
 class TestParsing(unittest.TestCase):
 
     def assertParses(self, source, expected, alt=False):  # noqa
-        parser = MarkdownParser()
+        parser = MarkdownParser(config=DEFAULT_TEST_CONFIG)
         parser.parse(dedent(source), new_document('<string>'))
         self.assertMultiLineEqual(
             dedent(expected).lstrip(),
@@ -121,19 +134,23 @@ class TestParsing(unittest.TestCase):
                     <raw format="html" xml:space="preserve">&lt;strong attr=&quot;some-attr&quot;&gt;special&lt;/strong&gt;</raw>
                   </paragraph>
                   <transition/>
-                  <table>
-                    <thead>
-                      <row>
-                        <entry>one</entry>
-                        <entry>two</entry>
-                      </row>
-                    </thead>
-                    <tbody>
-                      <row>
-                        <entry>ONE</entry>
-                        <entry>TWO</entry>
-                      </row>
-                    </tbody>
+                  <table classes="colwidths-auto">
+                    <tgroup stub="None">
+                      <colspec/>
+                      <colspec/>
+                      <thead>
+                        <row>
+                          <entry>one</entry>
+                          <entry>two</entry>
+                        </row>
+                      </thead>
+                      <tbody>
+                        <row>
+                          <entry>ONE</entry>
+                          <entry>TWO</entry>
+                        </row>
+                      </tbody>
+                    </tgroup>
                   </table>
                   <raw format="html" xml:space="preserve">&lt;video hello=&quot;world&quot;&gt;&lt;boo&gt;howdy&lt;/boo&gt;&lt;/video&gt;</raw>
                   <paragraph>wow</paragraph>

--- a/tests/test_markdown.py
+++ b/tests/test_markdown.py
@@ -56,6 +56,12 @@ class TestParsing(unittest.TestCase):
 
             ## [B](#b)
 
+            ### level 3
+
+            #### level 4
+
+            ## level 2
+
             ![ello](some-image.img)
 
             * one
@@ -105,6 +111,15 @@ class TestParsing(unittest.TestCase):
                   <title>
                     <reference refuri="#b">B</reference>
                   </title>
+                  <section ids="level-3" names="level-3">
+                    <title>level 3</title>
+                    <section ids="level-4" names="level-4">
+                      <title>level 4</title>
+                    </section>
+                  </section>
+                </section>
+                <section ids="level-2" names="level-2">
+                  <title>level 2</title>
                   <paragraph>
                     <image uri="some-image.img">ello</image>
                   </paragraph>

--- a/tests/test_sphinx.py
+++ b/tests/test_sphinx.py
@@ -142,17 +142,17 @@ class GenericTests(SphinxIntegrationTests):
         output = self.read_file('index.html')
         self.assertIn(
             ('<ul class="simple">\n'
-             '<li>Item A</li>\n'
-             '<li>Item B</li>\n'
-             '<li>Item C</li>\n'
+             '<li><p>Item A</p></li>\n'
+             '<li><p>Item B</p></li>\n'
+             '<li><p>Item C</p></li>\n'
              '</ul>'),
             output
         )
         self.assertIn(
             ('<ol class="simple">\n'
-             '<li>Item 1</li>\n'
-             '<li>Item 2</li>\n'
-             '<li>Item 3</li>\n'
+             '<li><p>Item 1</p></li>\n'
+             '<li><p>Item 2</p></li>\n'
+             '<li><p>Item 3</p></li>\n'
              '</ol>'),
             output
         )
@@ -207,16 +207,16 @@ class CustomExtensionTests(SphinxIntegrationTests):
     def test_integration(self):
         output = self.read_file('index.html')
         self.assertIn('<table ', output)
-        self.assertIn('<th class="head">abc</th>', output)
-        self.assertIn('<th class="head">data</th>', output)
+        self.assertIn('<th class="head"><p>abc</p></th>', output)
+        self.assertIn('<th class="head"><p>data</p></th>', output)
         self.assertIn('</table>', output)
 
         self.assertIn(
             ('<div class="contents topic" id="contents">\n'
              '<p class="topic-title first">Contents</p>\n'
              '<ul class="simple">\n'
-             '<li><a class="reference internal" href="#header" id="id1">Header</a><ul>\n'
-             '<li><a class="reference internal" href="#header-2" id="id2">Header 2</a></li>\n'
+             '<li><p><a class="reference internal" href="#header" id="id1">Header</a></p>\n<ul>\n'
+             '<li><p><a class="reference internal" href="#header-2" id="id2">Header 2</a></p></li>\n'
              '</ul>\n</li>\n</ul>'),
             output
             )


### PR DESCRIPTION
This fixes the tests and restores some functionality from v0.1. The test output of `<table>` had to be changed, that is just how docutils works these days, but other stuff behaves the same as before my previous PR at least with regards to the test examples.

Some other test failures were due to docutils changing things, unrelated to my PR. I've fixed them anyways in a separate commit.
