### PR TITLE
Fix inline math

### DIFF
--- a/tests/sphinx_code_block/conf.py
+++ b/tests/sphinx_code_block/conf.py
@@ -1,11 +1,8 @@
-
 # -*- coding: utf-8 -*-
 
 from sphinx_markdown_parser.parser import CommonMarkParser
 
 templates_path = ['_templates']
-source_suffix = '.md'
-source_parsers = { '.md': CommonMarkParser }
 master_doc = 'index'
 project = u'sphinxproj'
 copyright = u'2015, rtfd'
@@ -20,3 +17,8 @@ todo_include_todos = False
 html_theme = 'alabaster'
 html_static_path = ['_static']
 htmlhelp_basename = 'sphinxproj'
+
+
+def setup(app):
+    app.add_source_suffix('.md', 'markdown')
+    app.add_source_parser(CommonMarkParser)

--- a/tests/sphinx_custom_md/conf.py
+++ b/tests/sphinx_custom_md/conf.py
@@ -1,12 +1,9 @@
-
 # -*- coding: utf-8 -*-
 
 from sphinx_markdown_parser.parser import CommonMarkParser
 from sphinx_markdown_parser.transform import AutoStructify
 
 templates_path = ['_templates']
-source_suffix = '.markdown'
-source_parsers = { '.markdown': CommonMarkParser }
 master_doc = 'index'
 project = u'sphinxproj'
 copyright = u'2015, rtfd'
@@ -22,9 +19,12 @@ html_theme = 'alabaster'
 html_static_path = ['_static']
 htmlhelp_basename = 'sphinxproj'
 
+
 def setup(app):
+    app.add_source_suffix('.markdown', 'markdown')
+    app.add_source_parser(CommonMarkParser)
     app.add_config_value('markdown_parser_config', {
-            'enable_eval_rst': True,
-            'commonmark_suffixes': ['.markdown', '.hpp'],
-            }, True)
+        'enable_eval_rst': True,
+        'commonmark_suffixes': ['.markdown'],
+    }, True)
     app.add_transform(AutoStructify)

--- a/tests/sphinx_generic/conf.py
+++ b/tests/sphinx_generic/conf.py
@@ -1,11 +1,8 @@
-
 # -*- coding: utf-8 -*-
 
 from sphinx_markdown_parser.parser import CommonMarkParser
 
 templates_path = ['_templates']
-source_suffix = '.md'
-source_parsers = { '.md': CommonMarkParser }
 master_doc = 'index'
 project = u'sphinxproj'
 copyright = u'2015, rtfd'
@@ -20,3 +17,8 @@ todo_include_todos = False
 html_theme = 'alabaster'
 html_static_path = ['_static']
 htmlhelp_basename = 'sphinxproj'
+
+
+def setup(app):
+    app.add_source_suffix('.md', 'markdown')
+    app.add_source_parser(CommonMarkParser)

--- a/tests/sphinx_indented_code/conf.py
+++ b/tests/sphinx_indented_code/conf.py
@@ -1,11 +1,8 @@
-
 # -*- coding: utf-8 -*-
 
 from sphinx_markdown_parser.parser import CommonMarkParser
 
 templates_path = ['_templates']
-source_suffix = '.md'
-source_parsers = { '.md': CommonMarkParser }
 master_doc = 'index'
 project = u'sphinxproj'
 copyright = u'2015, rtfd'
@@ -20,3 +17,8 @@ todo_include_todos = False
 html_theme = 'alabaster'
 html_static_path = ['_static']
 htmlhelp_basename = 'sphinxproj'
+
+
+def setup(app):
+    app.add_source_suffix('.md', 'markdown')
+    app.add_source_parser(CommonMarkParser)

--- a/tests/sphinx_inline_math/conf.py
+++ b/tests/sphinx_inline_math/conf.py
@@ -1,0 +1,29 @@
+# -*- coding: utf-8 -*-
+
+from sphinx_markdown_parser.parser import CommonMarkParser
+from sphinx_markdown_parser.transform import AutoStructify
+
+templates_path = ['_templates']
+master_doc = 'index'
+project = u'sphinxproj'
+copyright = u'2015, rtfd'
+author = u'rtfd'
+version = '0.1'
+release = '0.1'
+highlight_language = 'python'
+language = None
+exclude_patterns = ['_build']
+pygments_style = 'sphinx'
+todo_include_todos = False
+html_theme = 'alabaster'
+html_static_path = ['_static']
+htmlhelp_basename = 'sphinxproj'
+
+
+def setup(app):
+    app.add_source_suffix('.md', 'markdown')
+    app.add_source_parser(CommonMarkParser)
+    app.add_config_value('markdown_parser_config', {
+        'enable_inline_math': True,
+    }, True)
+    app.add_transform(AutoStructify)

--- a/tests/sphinx_inline_math/index.md
+++ b/tests/sphinx_inline_math/index.md
@@ -1,0 +1,8 @@
+Header
+======
+
+Inline math: `$ E = mc^2 $`
+
+Two dollars: `$$`
+
+A dollar: `$`

--- a/tests/sphinx_nested_header_block/conf.py
+++ b/tests/sphinx_nested_header_block/conf.py
@@ -1,11 +1,8 @@
-
 # -*- coding: utf-8 -*-
 
 from sphinx_markdown_parser.parser import CommonMarkParser
 
 templates_path = ['_templates']
-source_suffix = '.md'
-source_parsers = { '.md': CommonMarkParser }
 master_doc = 'index'
 project = u'sphinxproj'
 copyright = u'2015, rtfd'
@@ -20,3 +17,8 @@ todo_include_todos = False
 html_theme = 'alabaster'
 html_static_path = ['_static']
 htmlhelp_basename = 'sphinxproj'
+
+
+def setup(app):
+    app.add_source_suffix('.md', 'markdown')
+    app.add_source_parser(CommonMarkParser)

--- a/tests/test_sphinx.py
+++ b/tests/test_sphinx.py
@@ -1,6 +1,5 @@
-import os
 import io
-import sys
+import os
 import shutil
 import unittest
 from contextlib import contextmanager
@@ -191,6 +190,7 @@ class IndentedCodeTests(unittest.TestCase):
             '<div class="highlight">'
         )
 
+
 class NestedHeaderBlock(unittest.TestCase):
 
     def test_integration(self):
@@ -199,6 +199,7 @@ class NestedHeaderBlock(unittest.TestCase):
             '_build/text/index.html',
             '<h1>'
         )
+
 
 class CustomExtensionTests(SphinxIntegrationTests):
 
@@ -220,3 +221,13 @@ class CustomExtensionTests(SphinxIntegrationTests):
              '</ul>\n</li>\n</ul>'),
             output
             )
+
+
+class InlineMathTests(SphinxIntegrationTests):
+    build_path = 'tests/sphinx_inline_math'
+
+    def test_integration(self):
+        output = self.read_file('index.html')
+        self.assertIn('>\\( E = mc^2 \\)<', output)
+        self.assertIn('>$$<', output)
+        self.assertIn('>$<', output)

--- a/tests/test_sphinx.py
+++ b/tests/test_sphinx.py
@@ -214,7 +214,7 @@ class CustomExtensionTests(SphinxIntegrationTests):
 
         self.assertIn(
             ('<div class="contents topic" id="contents">\n'
-             '<p class="topic-title first">Contents</p>\n'
+             '<p class="topic-title">Contents</p>\n'
              '<ul class="simple">\n'
              '<li><p><a class="reference internal" href="#header" id="id1">Header</a></p>\n<ul>\n'
              '<li><p><a class="reference internal" href="#header-2" id="id2">Header 2</a></p></li>\n'


### PR DESCRIPTION
with code from:

readthedocs/recommonmark#124
readthedocs/recommonmark#178
readthedocs/recommonmark#194

Fix the following traceback:

```
.venv/lib/python3.6/site-packages/sphinx/application.py:342: in build
    self.builder.build_all()
.venv/lib/python3.6/site-packages/sphinx/builders/__init__.py:260: in build_all
    self.build(None, summary=__('all source files'), method='all')
.venv/lib/python3.6/site-packages/sphinx/builders/__init__.py:311: in build
    updated_docnames = set(self.read())
.venv/lib/python3.6/site-packages/sphinx/builders/__init__.py:418: in read
    self._read_serial(docnames)
.venv/lib/python3.6/site-packages/sphinx/builders/__init__.py:439: in _read_serial
    self.read_doc(docname)
.venv/lib/python3.6/site-packages/sphinx/builders/__init__.py:479: in read_doc
    doctree = read_doc(self.app, self.env, self.env.doc2path(docname))
.venv/lib/python3.6/site-packages/sphinx/io.py:221: in read_doc
    pub.publish()
.venv/lib/python3.6/site-packages/docutils/core.py:219: in publish
    self.apply_transforms()
.venv/lib/python3.6/site-packages/docutils/core.py:200: in apply_transforms
    self.document.transformer.apply_transforms()
.venv/lib/python3.6/site-packages/sphinx/transforms/__init__.py:86: in apply_transforms
    super().apply_transforms()
.venv/lib/python3.6/site-packages/docutils/transforms/__init__.py:171: in apply_transforms
    transform.apply(**kwargs)
sphinx_markdown_parser/transform.py:345: in apply
    self.traverse(self.document)
sphinx_markdown_parser/transform.py:323: in traverse
    self.traverse(child)
sphinx_markdown_parser/transform.py:323: in traverse
    self.traverse(child)
sphinx_markdown_parser/transform.py:313: in traverse
    newnode = self.find_replace(c)
sphinx_markdown_parser/transform.py:297: in find_replace
    newnode = self.auto_inline_code(node)
sphinx_markdown_parser/transform.py:220: in auto_inline_code
    return self.state_machine.run_role('math', content=content)
sphinx_markdown_parser/states.py:123: in run_role
    content=content

role = 'math', rawtext = ' E = mc^2 ', text = ' E = mc^2 ', lineno = 4, inliner = <docutils.parsers.rst.states.Inliner object at 0x7fe9758a2518>, options = {}, content = ' E = mc^2 '

    def math_role(role, rawtext, text, lineno, inliner, options={}, content=[]):
        set_classes(options)
        i = rawtext.find('`')
>       text = rawtext.split('`')[1]
E       IndexError: list index out of range

.venv/lib/python3.6/site-packages/docutils/parsers/rst/roles.py:361: IndexError
```