### PR TITLE
include requirements.txt used in setup.py in sdist

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,4 @@
 include *.md
+include requirements.txt
 recursive-include docs *.md *.py Makefile
 graft tests


### PR DESCRIPTION
This PR add `requirements.txt` to the sdist of this package. Otherwise using `setup.py` of the source distribution fails when trying to read it to determine the dependencies.

It would be great if the pypi sdist could also be updated after merging this fix.