### PR TITLE
Remove all recommonmark references from code

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,10 +26,10 @@ The `MarkdownParser` is the recommonend parser for the following reasons.
 
 If you insist on using the `CommonMarkParser` I recommnend using [recommonmark](https://github.com/readthedocs/recommonmark) directly since we do not officially support that parser.
 
-| **Parser**         | **Source**                                  |
-| ------------------ | ------------------------------------------- |
-| `MarkdownParser`   | https://github.com/Python-Markdown/markdown |
-| `CommonMarkParser` | https://github.com/readthedocs/recommonmark |
+| **Parser**         | **Underlying Library**                       |
+| ------------------ | -------------------------------------------- |
+| `MarkdownParser`   | https://github.com/Python-Markdown/markdown  |
+| `CommonMarkParser` | https://github.com/readthedocs/commonmark.py |
 
 ## Getting Started
 
@@ -71,8 +71,8 @@ def setup(app):
         ],
     }, True)
 
-# for CommonMarkParser
-from recommonmark.parser import CommonMarkParser
+# for CommonMarkParser (please see note above!)
+from sphinx_markdown_parser.parser import CommonMarkParser
 
 def setup(app):
     app.add_source_suffix('.md', 'markdown')
@@ -150,15 +150,9 @@ For instance [this issue][sphinx-issue] and [this StackOverflow
 question][so-question] show that there is an interest in allowing `docutils`
 to use markdown as an alternative syntax.
 
-## Why another bridge to docutils?
-
-recommonmark uses the [python implementation][pcm] of [CommonMark][cm] while
-[remarkdown][rmd] implements a stand-alone parser leveraging [parsley][prs].
-
-Both output a [`docutils` document tree][dc] and provide scripts
-that leverage `docutils` for generation of different types of documents.
-
 ## Acknowledgement
+
+sphinx-markdown-parser is based on [recommonmark][rcm].
 
 recommonmark is mainly derived from [remarkdown][rmd] by Steve Genoud and
 leverages the python CommonMark implementation.
@@ -168,6 +162,7 @@ and is now maintained in the Read the Docs (rtfd) GitHub organization.
 
 [cm]: https://commonmark.org
 [pcm]: https://github.com/rtfd/CommonMark-py
+[rcm]: https://github.com/readthedocs/recommonmark
 [rmd]: https://github.com/sgenoud/remarkdown
 [prs]: https://github.com/pyga/parsley
 [lu-zero]: https://github.com/lu-zero

--- a/setup.py
+++ b/setup.py
@@ -45,12 +45,12 @@ setup(
     include_package_data=True,
     entry_points={
         'console_scripts': [
-            'cm2html = sphinx_markdown_parser.scripts:cm2html',
-            'cm2latex = sphinx_markdown_parser.scripts:cm2latex',
-            'cm2man = sphinx_markdown_parser.scripts:cm2man',
-            'cm2pseudoxml = sphinx_markdown_parser.scripts:cm2pseudoxml',
-            'cm2xetex = sphinx_markdown_parser.scripts:cm2xetex',
-            'cm2xml = sphinx_markdown_parser.scripts:cm2xml',
+            'md2html = sphinx_markdown_parser.scripts:md2html',
+            'md2latex = sphinx_markdown_parser.scripts:md2latex',
+            'md2man = sphinx_markdown_parser.scripts:md2man',
+            'md2pseudoxml = sphinx_markdown_parser.scripts:md2pseudoxml',
+            'md2xetex = sphinx_markdown_parser.scripts:md2xetex',
+            'md2xml = sphinx_markdown_parser.scripts:md2xml',
         ]
     }
 )

--- a/sphinx_markdown_parser/scripts.py
+++ b/sphinx_markdown_parser/scripts.py
@@ -15,61 +15,61 @@ except ImportError:
     pass
 
 from docutils.core import publish_cmdline, default_description
-from recommonmark.parser import CommonMarkParser
+from sphinx_markdown_parser.parser import MarkdownParser
 
-def cm2html():
+def md2html():
     description = (
         'Generate html document from markdown sources. ' + default_description
     )
     publish_cmdline(
-        writer_name='html', parser=CommonMarkParser(), description=description
+        writer_name='html', parser=MarkdownParser(), description=description
     )
 
-def cm2man():
+def md2man():
     description = (
         'Generate a manpage from markdown sources. ' + default_description
     )
     publish_cmdline(
         writer_name='manpage',
-        parser=CommonMarkParser(),
+        parser=MarkdownParser(),
         description=description
     )
 
-def cm2xml():
+def md2xml():
     description = (
         'Generate XML document from markdown sources. ' + default_description
     )
     publish_cmdline(
-        writer_name='xml', parser=CommonMarkParser(), description=description
+        writer_name='xml', parser=MarkdownParser(), description=description
     )
 
-def cm2pseudoxml():
+def md2pseudoxml():
     description = (
         'Generate pseudo-XML document from markdown sources. ' +
         default_description
     )
     publish_cmdline(
         writer_name='pseudoxml',
-        parser=CommonMarkParser(),
+        parser=MarkdownParser(),
         description=description
     )
 
-def cm2latex():
+def md2latex():
     description = (
         'Generate latex document from markdown sources. ' + default_description
     )
     publish_cmdline(
         writer_name='latex',
-        parser=CommonMarkParser(),
+        parser=MarkdownParser(),
         description=description
     )
 
-def cm2xetex():
+def md2xetex():
     description = (
         'Generate xetex document from markdown sources. ' + default_description
     )
     publish_cmdline(
         writer_name='latex',
-        parser=CommonMarkParser(),
+        parser=MarkdownParser(),
         description=description
     )


### PR DESCRIPTION
This PR does three things:

- It clarifies this projects relationship to recommomark a bit more clearly
- It removes the last remaining references to recommonmark from the code
- It uses the MarkdownParser for the command line utility and renames the to avoid name clashes with recommomark

I might even consider dropping the `CommonMarkParser` altogether. It just bloats this project and given that recommonmark continues to maintain it, it looks like wasted effort to me. 